### PR TITLE
Add info about Packagist availability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # psr7-middlewares
 
+
 [![Build Status](https://travis-ci.org/oscarotero/psr7-middlewares.svg)](https://travis-ci.org/oscarotero/psr7-middlewares)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/oscarotero/psr7-middlewares/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/oscarotero/psr7-middlewares/?branch=master)
 
-Collection of [PSR-7](http://www.php-fig.org/psr/psr-7/) middlewares
+Collection of [PSR-7](http://www.php-fig.org/psr/psr-7/) middlewares.
+
+It is installable and autoloadable via Composer as oscarotero/psr7-middlewares.
 
 ## Requirements
 


### PR DESCRIPTION
Not all GitHub PHP projects are available on Packagist, and some of those that are actually have different package names there than they do here!  So it's always nice to help the potential user find your code for inclusion in their composer.json file.  :-)
