### PR TITLE
Fixes Https Middleware to update port to 443 when changing scheme to https

### DIFF
--- a/src/Middleware/Https.php
+++ b/src/Middleware/Https.php
@@ -75,7 +75,7 @@ class Https
         $uri = $request->getUri();
 
         if (strtolower($uri->getScheme()) !== 'https') {
-            $uri = $uri->withScheme('https');
+            $uri = $uri->withScheme('https')->withPort('443');
 
             if ($this->redirectStatus) {
                 return self::getRedirectResponse($this->redirectStatus, $uri, $response);

--- a/tests/HttpsTest.php
+++ b/tests/HttpsTest.php
@@ -29,4 +29,18 @@ class HttpsTest extends Base
         $this->assertEquals($location, $response->getHeaderLine('Location'));
         $this->assertEquals($hsts, $response->getHeaderLine('Strict-Transport-Security'));
     }
+    public function testRedirectSchemeMatchesPort()
+    {
+        $url = 'http://domain.com:80';
+
+        $response = $this->execute(
+            [
+                Middleware::Https()->includeSubdomains(false),
+            ],
+            $url
+        );
+        $expectedLocation = 'https://domain.com';
+        $location = $response->getHeaderLine('Location');
+        $this->assertEquals($expectedLocation,$location);
+    }
 }


### PR DESCRIPTION
Issue #24 
Update Https middleware so that in addition to setting the URI scheme to 'https' it also updates the port to 443.

This prevents situations where there may be a mismatch between scheme and port in the generated redirect response (i.e. we won't end up with a string URI that looks like https://domain.com:80).
