### PR TITLE
Don't pass withPort a string. Should be set with an integer

### DIFF
--- a/src/Middleware/Https.php
+++ b/src/Middleware/Https.php
@@ -75,7 +75,7 @@ class Https
         $uri = $request->getUri();
 
         if (strtolower($uri->getScheme()) !== 'https') {
-            $uri = $uri->withScheme('https')->withPort('443');
+            $uri = $uri->withScheme('https')->withPort(443);
 
             if ($this->redirectStatus) {
                 return self::getRedirectResponse($this->redirectStatus, $uri, $response);


### PR DESCRIPTION
Sorry. I just pulled that change into the project I'm working on, and it caused Slim to throw an exception because I was setting the port as `withPort('443')`. I needed to pass the port as an integer instead of a string
