### PR TITLE
Ensure all buffers are discarded before outputting whoops.

### DIFF
--- a/src/Middleware/Whoops.php
+++ b/src/Middleware/Whoops.php
@@ -83,6 +83,8 @@ class Whoops
             $body->write($whoops->$method($exception));
 
             $response = $response->withStatus(500)->withBody($body);
+
+            while (ob_get_level()) ob_end_clean();
         }
 
         if ($this->catchErrors) {
@@ -94,7 +96,7 @@ class Whoops
 
     /**
      * Returns the whoops instance or create one.
-     * 
+     *
      * @param ServerRequestInterface $request
      *
      * @return Run


### PR DESCRIPTION
I was having issues where content had already been sent by code that was part of the stack that isn't really aware of the middleware stack. Specifically I have wrangled a PSR-7 middleware stack into a wordpress theme.

Let me know if you think there is a better way to do what I want, otherwise I'd be happy to see this PR merged.

Cheers Brad.
