### PR TITLE
Fix cache (using micheh/psr7-cache:^0.5.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		"paragonie/csp-builder": "^1.2",
 		"google/recaptcha": "^1.1",
 		"piwik/referrer-spam-blacklist": "^1.0",
-		"micheh/psr7-cache": "^0.3.0"
+		"micheh/psr7-cache": "^0.5.0"
 	},
 	"suggest": {
 		"aura/router": "To use AuraRouter",
@@ -71,5 +71,11 @@
 		"psr-4": {
 			"Psr7Middlewares\\": "src/"
 		}
+	},
+	"autoload-dev":{
+		"psr-4":{
+			"":"tests/"
+		}
 	}
+
 }

--- a/src/Middleware/Cache.php
+++ b/src/Middleware/Cache.php
@@ -2,6 +2,7 @@
 
 namespace Psr7Middlewares\Middleware;
 
+use Micheh\Cache\Header\RequestCacheControl;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -49,7 +50,7 @@ class Cache
     public function cacheControl($cacheControl)
     {
         if (!($cacheControl instanceof CacheControl)) {
-            $cacheControl = CacheControl::fromString($cacheControl);
+            $cacheControl = RequestCacheControl::fromString($cacheControl);
         }
 
         $this->cacheControl = $cacheControl;

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -11,7 +11,7 @@ class CacheTest extends Base
         $used = 0;
 
         $middlewares = [
-            Middleware::Cache(new Pool(new MemoryStore())),
+            Middleware::Cache(new Pool(new MemoryStore()))->cacheControl('max-age=3600'),
 
             function ($request, $response, $next) use (&$used) {
                 ++$used;


### PR DESCRIPTION
`CacheControl::fromString`  has been removed in `micheh/psr7-cache:^0.4`, and use `RequestCacheControl::fromString` instead.
