### PR TITLE
Pass the stream you're replacing to the `createStream` method.

### DIFF
--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -118,8 +118,9 @@ class ErrorHandler
 
         if ($this->isError($response->getStatusCode())) {
             $callable = $this->handler ?: [$this, 'defaultHandler'];
-
-            return $this->executeCallable($callable, $request, $response->withBody(self::createStream()));
+            $body = self::createStream($response->getBody());
+            
+            return $this->executeCallable($callable, $request, $response->withBody($body));
         }
 
         return $response;

--- a/src/Middleware/Gzip.php
+++ b/src/Middleware/Gzip.php
@@ -39,9 +39,11 @@ class Gzip
         $transformer = $resolver->resolve($encoding);
 
         if ($transformer) {
+            $body = $response->getBody();
+            
             return $response
                 ->withHeader('Content-Encoding', $encoding)
-                ->withBody($transformer($response->getBody(), self::createStream()));
+                ->withBody($transformer($body, self::createStream($body)));
         }
 
         return $response;

--- a/src/Middleware/ImageTransformer.php
+++ b/src/Middleware/ImageTransformer.php
@@ -185,7 +185,7 @@ class ImageTransformer
 
         $image->transform($transform);
 
-        $body = self::createStream();
+        $body = self::createStream($response->getBody());
         $body->write($image->getString());
 
         return $response

--- a/src/Middleware/Whoops.php
+++ b/src/Middleware/Whoops.php
@@ -81,11 +81,11 @@ class Whoops
         try {
             $response = $next($request, $response);
         } catch (\Throwable $exception) {
-            $body = self::createStream();
+            $body = self::createStream($response->getBody());
             $body->write($whoops->$method($exception));
             $response = $response->withStatus(500)->withBody($body);
         } catch (\Exception $exception) {
-            $body = self::createStream();
+            $body = self::createStream($response->getBody());
             $body->write($whoops->$method($exception));
             $response = $response->withStatus(500)->withBody($body);
         } finally {

--- a/src/Utils/StreamTrait.php
+++ b/src/Utils/StreamTrait.php
@@ -3,6 +3,7 @@
 namespace Psr7Middlewares\Utils;
 
 use Psr7Middlewares\Middleware;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Trait used to create streams.
@@ -12,11 +13,19 @@ trait StreamTrait
     /**
      * Get the stream factory.
      *
-     * @return \Psr\Http\Message\StreamInterface
+     * @param string|StreamInterface $file  Filename or stream it's replacing
+     * @param string                 $mode
+     * @return StreamInterface
      */
     private static function createStream($file = 'php://temp', $mode = 'r+')
     {
         $factory = Middleware::getStreamFactory();
+        $replacing = null;
+
+        if ($file instanceof StreamInterface) {
+            $replacing = $file;
+            $file = 'php://temp';
+        }
 
         if ($factory === null) {
             if (class_exists('Zend\\Diactoros\\Stream')) {
@@ -26,6 +35,7 @@ trait StreamTrait
             throw new \RuntimeException('Unable to create a stream. No stream factory defined');
         }
 
-        return call_user_func($factory, $file, $mode);
+        
+        return call_user_func($factory, $file, $mode, $replacing);
     }
 }


### PR DESCRIPTION
This method will try to use the same stream resource uri and will fall back to `php://temp`.
The stream that is being replaced is also passed to the factory as third argument. This will allow the factory to create a new stream with the same class (or affect it in some other way).
