### PR TITLE
add middleware to validate JSON request body with schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ $response = $dispatcher(ServerRequestFactory::fromGlobals(), new Response());
 * [Honeypot](#honeypot)
 * [Https](#https)
 * [ImageTransformer](#imagetransformer)
+* [JsonSchema](#jsonschema)
 * [LanguageNegotiation](#languagenegotiation)
 * [LeagueRoute](#leagueroute)
 * [MethodOverride](#methodoverride)
@@ -895,6 +896,30 @@ $middlewares = [
 
         return $next($request, $response);
     }
+];
+```
+
+### JsonSchema
+
+Uses [justinrainbow/json-schema](https://github.com/justinrainbow/json-schema) to validate an `application/json` request body using route-matched JSON schemas:
+
+```php
+use Psr7Middlewares\Middleware;
+use Psr7Middlewares\Middleware\JsonSchema;
+
+$middlewares = [
+
+    // Transform `application/json` into an object, which is a requirement of `justinrainbow/json-schema`.
+    Middleware::payload([
+        'forceArray' => false,
+    ]);
+
+    // Provide a map of route-prefixes to JSON schema files.
+    Middleware::jsonSchema([
+        '/en/v1/users' => WEB_ROOT . '/json-schema/en.v1.users.json',
+        '/en/v1/posts' => WEB_ROOT . '/json-schema/en.v1.posts.json',
+        '/en/v2/posts' => WEB_ROOT . '/json-schema/en.v2.posts.json',
+    ]);
 ];
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,8 @@
 		"google/recaptcha": "^1.1",
 		"piwik/referrer-spam-blacklist": "^1.0",
 		"micheh/psr7-cache": "^0.5.0",
+		"justinrainbow/json-schema": ">=3.0",
+		"mikey179/vfsStream": "^1.6",
 		"friendsofphp/php-cs-fixer": "^1.12"
 	},
 	"suggest": {
@@ -66,6 +68,7 @@
 		"paragonie/csp-builder": "To use Csp",
 		"google/recaptcha": "To use Recaptcha",
 		"piwik/referrer-spam-blacklist": "To use BlockSpam",
+		"justinrainbow/json-schema": "To validate JSON with route-matched schemas.",
 		"micheh/psr7-cache": "To use Cache"
 	},
 	"autoload": {

--- a/src/Middleware/JsonSchema.php
+++ b/src/Middleware/JsonSchema.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Psr7Middlewares\Middleware;
+
+use JsonSchema\Validator;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class JsonSchema
+{
+    /** @var string[] */
+    private $schemas;
+
+    /**
+     * JsonSchema constructor.
+     * @param string[] $schemas [uri => file] An associative array of HTTP URI to validation schema.
+     */
+    public function __construct(array $schemas)
+    {
+        $this->schemas = $schemas;
+    }
+
+    /**
+     * Execute the middleware.
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface      $response
+     * @param callable               $next
+     *
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        $schema = $this->getSchema($request);
+
+        if (is_object($schema)) {
+            $value = $request->getParsedBody();
+            if (!is_object($value)) {
+                return $this->invalidateResponse(
+                    $response,
+                    sprintf('Parsed body must be an object. Type %s is invalid.', gettype($value))
+                );
+            }
+
+            $validator = new Validator();
+            $validator->check($value, $schema);
+
+            if (!$validator->isValid()) {
+                return $this->invalidateResponse(
+                    $response,
+                    'Unprocessable Entity',
+                    [
+                        'Content-Type' => 'application/json',
+                    ],
+                    json_encode($validator->getErrors(), JSON_UNESCAPED_SLASHES)
+                );
+            }
+        }
+
+        if ($next) {
+            return $next($request, $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @param string $reason
+     * @param string[] $headers
+     * @param string|null $body
+     * @return ResponseInterface
+     */
+    private function invalidateResponse(ResponseInterface $response, $reason, array $headers = [], $body = null)
+    {
+        $response = $response->withStatus(422, $reason);
+
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        if ($body !== null) {
+            $stream = $response->getBody();
+            $stream->write($body);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @return object|null
+     */
+    private function getSchema(ServerRequestInterface $request)
+    {
+        foreach ($this->schemas as $pattern => $file) {
+            $uri = $request->getUri();
+            $path = $uri->getPath();
+
+            if (stripos($path, $pattern) === 0) {
+                $file = $this->normalizeFilePath($file);
+
+                return (object) [
+                    '$ref' => $file,
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string
+     * @return string
+     */
+    private function normalizeFilePath($path)
+    {
+        if (parse_url($path, PHP_URL_SCHEME)) {
+            // The schema file already has a scheme, e.g. `file://` or `vfs://`.
+            return $path;
+        }
+
+        return 'file://' . $path;
+    }
+}

--- a/src/Middleware/Payload.php
+++ b/src/Middleware/Payload.php
@@ -14,6 +14,18 @@ class Payload
 {
     use Utils\ResolverTrait;
 
+    /** @var mixed[] */
+    private $options;
+
+    /**
+     * Payload constructor.
+     * @param mixed[] $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
     /**
      * Execute the middleware.
      *
@@ -26,7 +38,7 @@ class Payload
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
         if (!$request->getParsedBody() && in_array($request->getMethod(), ['POST', 'PUT', 'PATCH', 'DELETE', 'COPY', 'LOCK', 'UNLOCK'], true)) {
-            $resolver = $this->resolver ?: new Transformers\BodyParser();
+            $resolver = $this->resolver ?: new Transformers\BodyParser($this->options);
             $transformer = $resolver->resolve(trim($request->getHeaderLine('Content-Type')));
 
             if ($transformer) {

--- a/src/Transformers/BodyParser.php
+++ b/src/Transformers/BodyParser.php
@@ -10,11 +10,22 @@ use DomainException;
  */
 class BodyParser extends Resolver
 {
-    public function __construct()
+    /** @var mixed[] */
+    private $options = [
+        // When true, returned objects will be converted into associative arrays.
+        'forceArray' => true,
+    ];
+
+    /**
+     * BodyParser constructor.
+     * @param mixed[] $options
+     */
+    public function __construct(array $options = [])
     {
         $this->add('application/json', [$this, 'json']);
         $this->add('application/x-www-form-urlencoded', [$this, 'urlencode']);
         $this->add('text/csv', [$this, 'csv']);
+        $this->options = array_merge($this->options, $options);
     }
 
     /**
@@ -36,11 +47,13 @@ class BodyParser extends Resolver
      *
      * @param StreamInterface $body
      *
-     * @return array
+     * @return array|object Returns an array when $assoc is true, and an object when $assoc is false.
      */
     public function json(StreamInterface $body)
     {
-        $data = json_decode((string) $body, true);
+        $assoc = (bool)$this->options['forceArray'];
+
+        $data = json_decode((string) $body, $assoc);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new DomainException(json_last_error_msg());

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -1,5 +1,6 @@
 <?php
 
+use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
@@ -8,16 +9,30 @@ use Relay\RelayBuilder;
 
 abstract class Base extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @param string $uri
+     * @param array $headers
+     * @param array $server
+     * @return ServerRequest
+     */
     protected function request($uri = '', array $headers = array(), array $server = array())
     {
         return (new ServerRequest($server, [], $uri, null, 'php://temp', $headers))->withUri(new Uri($uri));
     }
 
+    /**
+     * @param array $headers
+     * @return Response
+     */
     protected function response(array $headers = array())
     {
         return new Response('php://temp', 200, $headers);
     }
 
+    /**
+     * @param string $content
+     * @return Stream
+     */
     protected function stream($content = '')
     {
         $stream = new Stream('php://temp', 'r+');
@@ -29,6 +44,12 @@ abstract class Base extends PHPUnit_Framework_TestCase
         return $stream;
     }
 
+    /**
+     * @param callable[] $middlewares
+     * @param ServerRequest $request
+     * @param Response $response
+     * @return ResponseInterface
+     */
     protected function dispatch(array $middlewares, ServerRequest $request, Response $response)
     {
         $dispatcher = (new RelayBuilder())->newInstance($middlewares);
@@ -36,6 +57,12 @@ abstract class Base extends PHPUnit_Framework_TestCase
         return $dispatcher($request, $response);
     }
 
+    /**
+     * @param callable[] $middlewares
+     * @param string $url
+     * @param array $headers
+     * @return ResponseInterface
+     */
     protected function execute(array $middlewares, $url = '', array $headers = array())
     {
         $request = $this->request($url, $headers);

--- a/tests/BodyParserTest.php
+++ b/tests/BodyParserTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Psr7Middlewares\Transformers\BodyParser;
+
+/**
+ * @covers \Psr7Middlewares\Transformers\BodyParser
+ */
+class BodyParserTest extends Base
+{
+    public function testDefaultJsonParser()
+    {
+        $expected = [
+            'foo' => 'bar',
+            'fiz' => [
+                'buz' => true,
+            ],
+        ];
+
+        $actual = (new BodyParser())->json(
+            $this->stream(json_encode($expected))
+        );
+
+        self::assertArraySubset($expected, $actual);
+    }
+
+    public function testJsonObjectParser()
+    {
+        $expected = [
+            'foo' => 'bar',
+            'fiz' => [
+                'buz' => true,
+            ],
+        ];
+
+        $actual = (new BodyParser(['forceArray' => false]))->json(
+            $this->stream(json_encode($expected))
+        );
+
+        self::assertInstanceOf(\stdClass::class, $actual);
+        self::assertObjectHasAttribute('foo', $actual);
+        self::assertEquals('bar', $actual->foo);
+        self::assertObjectHasAttribute('fiz', $actual);
+        self::assertInstanceOf(\stdClass::class, $actual->fiz);
+        self::assertObjectHasAttribute('buz', $actual->fiz);
+        self::assertTrue($actual->fiz->buz);
+    }
+
+    public function testFormUrlEncoded()
+    {
+        $expected = [
+            'foo' => 'bar',
+            'fiz' => [
+                'fiz' => 'buz',
+                'buz' => true,
+            ],
+        ];
+
+        $actual = (new BodyParser())->urlencode(
+            $this->stream(http_build_query($expected))
+        );
+
+        self::assertArraySubset($expected, $actual);
+    }
+
+    public function testEmptyFormUrlEncoded()
+    {
+        $actual = (new BodyParser())->urlencode(
+            $this->stream('')
+        );
+
+        self::assertInternalType('array', $actual);
+    }
+
+    public function testCsv()
+    {
+        $actual = (new BodyParser())->csv(
+            $this->stream(<<<'CSV'
+col1,col2,col3,col4
+foo,bar,fiz,buz
+CSV
+)
+        );
+
+        self::assertArraySubset(
+            [
+                [
+                    'col1',
+                    'col2',
+                    'col3',
+                    'col4',
+                ],
+                [
+                    'foo',
+                    'bar',
+                    'fiz',
+                    'buz',
+                ],
+            ],
+            $actual
+        );
+    }
+
+    public function testEmptyCsv()
+    {
+        $actual = (new BodyParser())->csv(
+            $this->stream('')
+        );
+
+        self::assertInternalType('array', $actual);
+    }
+}
+

--- a/tests/JsonSchemaTest.php
+++ b/tests/JsonSchemaTest.php
@@ -1,0 +1,206 @@
+<?php
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamFile;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr7Middlewares\Middleware\JsonSchema;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Stream;
+
+/**
+ * @covers \Psr7Middlewares\Middleware\JsonSchema
+ */
+class JsonSchemaTest extends Base
+{
+    /** @var JsonSchema */
+    private $validator;
+
+    /** @var vfsStreamFile */
+    private $schema;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $root = vfsStream::setup('test');
+        $this->schema = vfsStream::newFile('schema.json');
+        $root->addChild($this->schema);
+
+        $this->validator = new JsonSchema([
+            '/en/v1/users' => $this->schema->url(),
+        ]);
+
+        file_put_contents($this->schema->url(), <<<'JSON'
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "object",
+      "properties": {
+        "given": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "given",
+        "family"
+      ]
+    },
+    "email": {
+        "type": "string",
+        "format": "email"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "email"
+  ]
+}
+JSON
+        );
+    }
+
+    public function testInvalidJson()
+    {
+        $request = $this->request('/en/v1/users')
+            ->withParsedBody(json_decode(json_encode([
+                'foo' => 'bar',
+            ])));
+
+        $response = $this->dispatch([$this->validator], $request, new Response());
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertGreaterThanOrEqual(400, $response->getStatusCode(), $response->getBody());
+    }
+
+    public function dataInvalidParsedBody()
+    {
+        return [
+            ['InvalidBody'],
+            [1234],
+            [1234.56],
+            [true],
+            [new \stdClass()],
+            [['foo' => 'bar']],
+            [STDERR],
+        ];
+    }
+
+    /**
+     * @dataProvider dataInvalidParsedBody
+     * @param mixed $parsedBody
+     */
+    public function testInvalidParsedBody($parsedBody)
+    {
+        $request = $this->request('/en/v1/users')
+            ->withParsedBody($parsedBody);
+
+        $response = $this->dispatch([$this->validator], $request, new Response());
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertGreaterThanOrEqual(400, $response->getStatusCode(), $response->getBody());
+    }
+
+    public function testValidJson()
+    {
+        $request = $this->request('/en/v1/users')
+            ->withParsedBody(json_decode(json_encode([
+                'id' => '1234',
+                'name' => [
+                    'given' => 'Foo',
+                    'family' => 'Bar'
+                ],
+                'email' => 'foo.bar@example.com',
+            ])));
+
+        $response = $this->dispatch([$this->validator], $request, new Response());
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertGreaterThanOrEqual(200, $response->getStatusCode(), $response->getBody());
+    }
+
+    public function testUnmatchedRouteBypassesValidation()
+    {
+        $request = $this->request('/en/v1/posts')
+            ->withParsedBody(json_decode(json_encode([
+                'foo' => 'bar',
+            ])));
+
+        $response = $this->dispatch([$this->validator], $request, new Response());
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertGreaterThanOrEqual(200, $response->getStatusCode(), $response->getBody());
+    }
+
+    public function testSubRouteMatchesValidator()
+    {
+        $request = $this->request('/en/v1/users')
+            ->withParsedBody(json_decode(json_encode([
+                'foo' => 'bar',
+            ])));
+
+        $response = $this->dispatch([$this->validator], $request, new Response());
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertGreaterThanOrEqual(400, $response->getStatusCode(), $response->getBody());
+    }
+
+    public function testPayloadCollaborationWithValidJson()
+    {
+        $request = $this->request('/en/v1/users', ['Content-Type' => 'application/json'])
+            ->withMethod('POST')
+            ->withBody($this->stream(json_encode([
+                'id' => '1234',
+                'name' => [
+                    'given' => 'Foo',
+                    'family' => 'Bar'
+                ],
+                'email' => 'foo.bar@example.com',
+            ])));
+
+        $response = $this->dispatch(
+            [
+                new \Psr7Middlewares\Middleware\Payload([
+                    'associative' => false,
+                ]),
+                $this->validator,
+            ],
+            $request,
+            new Response()
+        );
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertGreaterThanOrEqual(200, $response->getStatusCode(), $response->getReasonPhrase());
+    }
+
+    public function testPayloadCollaborationWithInvalidJson()
+    {
+        $request = $this->request('/en/v1/users', ['Content-Type' => 'application/json'])
+            ->withMethod('POST')
+            ->withBody($this->stream('InvalidJson'));
+
+        $response = $this->dispatch(
+            [
+                new \Psr7Middlewares\Middleware\Payload([
+                    'associative' => false,
+                ]),
+                $this->validator,
+            ],
+            $request,
+            new Response()
+        );
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertGreaterThanOrEqual(400, $response->getStatusCode(), $response->getReasonPhrase());
+    }
+}


### PR DESCRIPTION
add JsonSchema middleware to validate request body using route-matched JSON schema files.

uses `justinrainbow/json-schema:>=3.0`. earlier versions resolve schema files differently and i chose not support it. i'd be happy to add support if requested.

route-matching is performed by prefix, e.g.:

``` php
Middleware::JsonSchema([
    '/en/v1/users' => WEB_ROOT . '/json-schema/en.v1.users.json',
    '/en/v1/posts' => WEB_ROOT . '/json-schema/en.v1.posts.json',
    '/en/v2/posts' => WEB_ROOT . '/json-schema/en.v2.posts.json',
]);
```

failed validation and malformed JSON will result in a short-circuited 422 response.

should the status code, message, and/or short-circuit behavior be configurable?
