### PR TITLE
split a simpler json-schema validator from the route-based-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,16 +921,8 @@ Uses [justinrainbow/json-schema](https://github.com/justinrainbow/json-schema) t
 use Psr7Middlewares\Middleware;
 
 $middlewares = [
-
-    // Transform `application/json` into an object, which is a requirement of `justinrainbow/json-schema`.
-    Middleware::payload([
-        'forceArray' => false,
-    ]),
-    
-    // Specify a JSON file (publicly-accessible in this example), or a JSON string decoded into object-notation.
-    Middleware::jsonValidator((object) [
-        '$ref' => WEB_ROOT . '/json-schema/en.v1.users.json',
-    ])
+    Middleware::payload(['forceArray' => false]),
+    JsonValidator::fromFile(new \SplFileObject(WEB_ROOT . '/json-schema/en.v1.users.json')),
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -913,6 +913,27 @@ $middlewares = [
 ];
 ```
 
+### JsonValidator
+
+Uses [justinrainbow/json-schema](https://github.com/justinrainbow/json-schema) to validate an `application/json` request body with a JSON schema:
+
+```php
+use Psr7Middlewares\Middleware;
+
+$middlewares = [
+
+    // Transform `application/json` into an object, which is a requirement of `justinrainbow/json-schema`.
+    Middleware::payload([
+        'forceArray' => false,
+    ]),
+    
+    // Specify a JSON file (publicly-accessible in this example), or a JSON string decoded into object-notation.
+    Middleware::jsonValidator((object) [
+        '$ref' => WEB_ROOT . '/json-schema/en.v1.users.json',
+    ])
+];
+```
+
 ### JsonSchema
 
 Uses [justinrainbow/json-schema](https://github.com/justinrainbow/json-schema) to validate an `application/json` request body using route-matched JSON schemas:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require-dev": {
 		"zendframework/zend-diactoros": "1.*",
 		"relay/relay": "1.*",
-		"nikic/fast-route": "0.*",
+		"nikic/fast-route": "^0.7",
 		"aura/router": "^3.0",
 		"aura/session": "2.*",
 		"phpunit/phpunit": ">=4.8",

--- a/src/Middleware/JsonSchema.php
+++ b/src/Middleware/JsonSchema.php
@@ -33,8 +33,8 @@ class JsonSchema
     {
         $schema = $this->getSchema($request);
 
-        if (is_object($schema)) {
-            $validator = new JsonValidator($schema);
+        if ($schema instanceof \SplFileObject) {
+            $validator = JsonValidator::fromFile($schema);
             return $validator($request, $response, $next);
         }
 
@@ -44,20 +44,16 @@ class JsonSchema
     /**
      * @param ServerRequestInterface $request
      *
-     * @return object|null
+     * @return \SplFileObject|null
      */
     private function getSchema(ServerRequestInterface $request)
     {
+        $uri = $request->getUri();
+        $path = $uri->getPath();
+
         foreach ($this->schemas as $pattern => $file) {
-            $uri = $request->getUri();
-            $path = $uri->getPath();
-
             if (stripos($path, $pattern) === 0) {
-                $file = $this->normalizeFilePath($file);
-
-                return (object) [
-                    '$ref' => $file,
-                ];
+                return new \SplFileObject($this->normalizeFilePath($file));
             }
         }
 

--- a/src/Middleware/JsonValidator.php
+++ b/src/Middleware/JsonValidator.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Psr7Middlewares\Middleware;
+
+use JsonSchema\Validator;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class JsonValidator
+{
+    /** @var \stdClass */
+    private $schema;
+
+    /**
+     * JsonSchema constructor.
+     *
+     * @param \stdClass $schema A JSON-decoded object-representation of the schema.
+     */
+    public function __construct(\stdClass $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * Execute the middleware.
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @param callable $next
+     *
+     * @return ResponseInterface
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     * @throws \JsonSchema\Exception\ExceptionInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        $value = $request->getParsedBody();
+        if (!is_object($value)) {
+            return $this->invalidateResponse(
+                $response,
+                sprintf('Parsed body must be an object. Type %s is invalid.', gettype($value))
+            );
+        }
+
+        $validator = new Validator();
+        $validator->check($value, $this->schema);
+
+        if (!$validator->isValid()) {
+            return $this->invalidateResponse(
+                $response,
+                'Unprocessable Entity',
+                [
+                    'Content-Type' => 'application/json',
+                ],
+                json_encode($validator->getErrors(), JSON_UNESCAPED_SLASHES)
+            );
+        }
+
+        return $next($request, $response);
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @param string $reason
+     * @param string[] $headers
+     * @param string|null $body
+     *
+     * @return ResponseInterface
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     */
+    private function invalidateResponse(ResponseInterface $response, $reason, array $headers = [], $body = null)
+    {
+        $response = $response->withStatus(422, $reason);
+
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        if ($body !== null) {
+            $stream = $response->getBody();
+            $stream->write($body);
+        }
+
+        return $response;
+    }
+}

--- a/src/Middleware/JsonValidator.php
+++ b/src/Middleware/JsonValidator.php
@@ -13,12 +13,57 @@ class JsonValidator
 
     /**
      * JsonSchema constructor.
+     * Consider using one of the following factories instead of invoking the controller directly:
+     *  - JsonValidator::fromFile()
+     *  - JsonValidator::fromEncodedString()
+     *  - JsonValidator::fromDecodedObject()
+     *  - JsonValidator::fromArray()
      *
      * @param \stdClass $schema A JSON-decoded object-representation of the schema.
      */
     public function __construct(\stdClass $schema)
     {
         $this->schema = $schema;
+    }
+
+    /**
+     * @param \stdClass $schema
+     * @return static|callable
+     */
+    public static function fromDecodedObject(\stdClass $schema)
+    {
+        return new static($schema);
+    }
+
+    /**
+     * @param \SplFileObject $file
+     * @return static|callable
+     */
+    public static function fromFile(\SplFileObject $file)
+    {
+        $schema = (object)[
+            '$ref' => $file->getPathname(),
+        ];
+
+        return new static($schema);
+    }
+
+    /**
+     * @param string $json
+     * @return static|callable
+     */
+    public static function fromEncodedString($json)
+    {
+        return static::fromDecodedObject(json_decode($json, false));
+    }
+
+    /**
+     * @param array $json
+     * @return static|callable
+     */
+    public static function fromArray(array $json)
+    {
+        return static::fromEncodedString(json_encode($json, JSON_UNESCAPED_SLASHES));
     }
 
     /**

--- a/tests/JsonValidatorTest.php
+++ b/tests/JsonValidatorTest.php
@@ -1,73 +1,58 @@
 <?php
 
 use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamFile;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr7Middlewares\Middleware\JsonSchema;
+use Psr7Middlewares\Middleware\JsonValidator;
 use Zend\Diactoros\Response;
-use Zend\Diactoros\ServerRequest;
-use Zend\Diactoros\Stream;
 
 /**
- * @covers \Psr7Middlewares\Middleware\JsonSchema
+ * @covers \Psr7Middlewares\Middleware\JsonValidator
  */
-class JsonSchemaTest extends Base
+class JsonValidatorTest extends Base
 {
-    /** @var JsonSchema */
+    /** @var JsonValidator */
     private $validator;
 
-    /** @var vfsStreamFile */
-    private $schema;
+    /** @var [] */
+    private static $schema = [
+        '$schema' => 'http://json-schema.org/draft-04/schema#',
+        'type' => 'object',
+        'properties' => [
+            'id' => [
+                'type' => 'string'
+            ],
+            'name' => [
+                'type' => 'object',
+                'properties' => [
+                    'given' => [
+                        'type' => 'string'
+                    ],
+                    'family' => [
+                        'type' => 'string'
+                    ]
+                ],
+                'required' => [
+                    'given',
+                    'family'
+                ]
+            ],
+            'email' => [
+                'type' => 'string',
+                'format' => 'email'
+            ]
+        ],
+        'required' => [
+            'id',
+            'name',
+            'email'
+        ]
+    ];
 
     protected function setUp()
     {
         parent::setUp();
 
-        $root = vfsStream::setup('test');
-        $this->schema = vfsStream::newFile('schema.json');
-        $root->addChild($this->schema);
-
-        $this->validator = new JsonSchema([
-            '/en/v1/users' => $this->schema->url(),
-        ]);
-
-        file_put_contents($this->schema->url(), <<<'JSON'
-{
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "properties": {
-    "id": {
-      "type": "string"
-    },
-    "name": {
-      "type": "object",
-      "properties": {
-        "given": {
-          "type": "string"
-        },
-        "family": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "given",
-        "family"
-      ]
-    },
-    "email": {
-        "type": "string",
-        "format": "email"
-    }
-  },
-  "required": [
-    "id",
-    "name",
-    "email"
-  ]
-}
-JSON
-        );
+        $this->validator = new JsonValidator(json_decode(json_encode(self::$schema)));
     }
 
     public function testInvalidJson()
@@ -126,35 +111,37 @@ JSON
         $response = $this->dispatch([$this->validator], $request, new Response());
 
         self::assertInstanceOf(ResponseInterface::class, $response);
-        self::assertGreaterThanOrEqual(200, $response->getStatusCode(), $response->getBody());
-        self::assertLessThan(300, $response->getStatusCode(), $response->getBody());
+        self::assertGreaterThanOrEqual(200, $response->getStatusCode(), $response->getReasonPhrase());
+        self::assertLessThan(300, $response->getStatusCode(), $response->getReasonPhrase());
     }
 
-    public function testUnmatchedRouteBypassesValidation()
+    public function testValidJsonFromFileReference()
     {
-        $request = $this->request('/en/v1/posts')
-            ->withParsedBody(json_decode(json_encode([
-                'foo' => 'bar',
-            ])));
+        $root = vfsStream::setup('test');
+        $file = vfsStream::newFile('schema.json');
+        $root->addChild($file);
 
-        $response = $this->dispatch([$this->validator], $request, new Response());
+        file_put_contents($file->url(), json_encode(self::$schema));
 
-        self::assertInstanceOf(ResponseInterface::class, $response);
-        self::assertGreaterThanOrEqual(200, $response->getStatusCode(), $response->getBody());
-        self::assertLessThan(300, $response->getStatusCode(), $response->getBody());
-    }
+        $this->validator = new JsonValidator((object) [
+            '$ref' => $file->url(),
+        ]);
 
-    public function testSubRouteMatchesValidator()
-    {
         $request = $this->request('/en/v1/users')
             ->withParsedBody(json_decode(json_encode([
-                'foo' => 'bar',
+                'id' => '1234',
+                'name' => [
+                    'given' => 'Foo',
+                    'family' => 'Bar'
+                ],
+                'email' => 'foo.bar@example.com',
             ])));
 
         $response = $this->dispatch([$this->validator], $request, new Response());
 
         self::assertInstanceOf(ResponseInterface::class, $response);
-        self::assertGreaterThanOrEqual(400, $response->getStatusCode(), $response->getBody());
+        self::assertGreaterThanOrEqual(200, $response->getStatusCode(), $response->getReasonPhrase());
+        self::assertLessThan(300, $response->getStatusCode(), $response->getReasonPhrase());
     }
 
     public function testPayloadCollaborationWithValidJson()
@@ -183,7 +170,7 @@ JSON
 
         self::assertInstanceOf(ResponseInterface::class, $response);
         self::assertGreaterThanOrEqual(200, $response->getStatusCode(), $response->getReasonPhrase());
-        self::assertLessThan(300, $response->getStatusCode(), $response->getBody());
+        self::assertLessThan(300, $response->getStatusCode(), $response->getReasonPhrase());
     }
 
     public function testPayloadCollaborationWithInvalidJson()

--- a/tests/JsonValidatorTest.php
+++ b/tests/JsonValidatorTest.php
@@ -52,7 +52,7 @@ class JsonValidatorTest extends Base
     {
         parent::setUp();
 
-        $this->validator = new JsonValidator(json_decode(json_encode(self::$schema)));
+        $this->validator = JsonValidator::fromArray(self::$schema);
     }
 
     public function testInvalidJson()
@@ -123,9 +123,7 @@ class JsonValidatorTest extends Base
 
         file_put_contents($file->url(), json_encode(self::$schema));
 
-        $this->validator = new JsonValidator((object) [
-            '$ref' => $file->url(),
-        ]);
+        $this->validator = JsonValidator::fromFile(new \SplFileObject($file->url()));
 
         $request = $this->request('/en/v1/users')
             ->withParsedBody(json_decode(json_encode([


### PR DESCRIPTION
split a simpler json-schema validator from the multi-validator. the simple validator handles a single schema and there is no route-based logic. the file-per-route implementation consumes the simple validator.