### PR TITLE
Use Content-Type text/plain for robots.txt

### DIFF
--- a/src/Middleware/Robots.php
+++ b/src/Middleware/Robots.php
@@ -36,6 +36,8 @@ class Robots
     public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next)
     {
         if ($request->getUri()->getPath() === '/robots.txt') {
+            $response = $response->withHeader('Content-Type', 'text/plain');
+
             if ($this->allow) {
                 $response->getBody()->write("User-Agent: *\nAllow: /");
 


### PR DESCRIPTION
I'd expect robots.txt to have a text/plain Content-Type instead of text/html.