### PR TITLE
Add ext-mcrypt to dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 		"php": ">=5.5.0"
 	},
 	"require-dev": {
+		"ext-mcrypt": "*",
 		"zendframework/zend-diactoros": "1.*",
 		"relay/relay": "1.*",
 		"nikic/fast-route": "0.*",


### PR DESCRIPTION
The test suite relies on the `mcrypt` extension being installed. If not present, `FormTimestampTest` fails with `Error: Call to undefined function Psr7Middlewares\Utils\mcrypt_create_iv()`.

Alternatively we could mark the tests as skipped if the extension is not present.