### PR TITLE
Update fast-route dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require-dev": {
 		"zendframework/zend-diactoros": "1.*",
 		"relay/relay": "1.*",
-		"nikic/fast-route": "0.*",
+		"nikic/fast-route": "^0.7",
 		"aura/router": "^3.0",
 		"aura/session": "2.*",
 		"phpunit/phpunit": ">=4.8",


### PR DESCRIPTION
Update dependency on nikic/fast-route from "0.*" to "^0.7" to resolve conflict with "league/route".