### PR TITLE
Allow the Payload middleware to override previously parsed body.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="./tests/bootstrap.php" stderr="true">
+<phpunit bootstrap="./tests/bootstrap.php" stderr="true" beStrictAboutTestsThatDoNotTestAnything="true">
 	<testsuites>
 		<testsuite name="All tests">
 			<directory>./tests/</directory>


### PR DESCRIPTION
Builds upon #55 for changes in how to deal with unit tests.