### PR TITLE
allow JSON-validator default error-handler to be overridden.

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,10 +919,41 @@ Uses [justinrainbow/json-schema](https://github.com/justinrainbow/json-schema) t
 
 ```php
 use Psr7Middlewares\Middleware;
+use Psr7Middlewares\Middleware\JsonValidator;
 
+// Validate using a file:
 $middlewares = [
     Middleware::payload(['forceArray' => false]),
     JsonValidator::fromFile(new \SplFileObject(WEB_ROOT . '/json-schema/en.v1.users.json')),
+];
+
+// Validate using an array:
+$middlewares = [
+    Middleware::payload(['forceArray' => false]),
+    JsonValidator::fromArray([
+        '$schema' => 'http://json-schema.org/draft-04/schema#',
+        'type' => 'object',
+        'properties' => [
+            'id' => [
+                'type' => 'string'
+            ],
+        ],
+        'required' => [
+            'id',
+        ]
+    ]);
+];
+
+// Override the default error handler, which responds with a 422 status code and application/json Content-Type:
+$middlewares = [
+    Middleware::payload(['forceArray' => false]),
+    JsonValidator::fromFile(new \SplFileObject('schema.json'))
+        ->setErrorHandler(function ($request, $response, array $errors) {
+            $response->getBody()->write('Failed JSON validation.');
+            
+            return $response->withStatus(400, 'Oops')
+                ->withHeader('Content-Type', 'text/plain');
+        }),
 ];
 ```
 

--- a/src/Middleware/JsonSchema.php
+++ b/src/Middleware/JsonSchema.php
@@ -10,6 +10,9 @@ class JsonSchema
     /** @var string[] */
     private $schemas;
 
+    /** @var callable|null */
+    private $errorHandler;
+
     /**
      * JsonSchema constructor.
      *
@@ -35,6 +38,10 @@ class JsonSchema
 
         if ($schema instanceof \SplFileObject) {
             $validator = JsonValidator::fromFile($schema);
+            if (is_callable($this->errorHandler)) {
+                $validator->errorHandler($this->errorHandler);
+            }
+
             return $validator($request, $response, $next);
         }
 
@@ -73,5 +80,20 @@ class JsonSchema
         }
 
         return 'file://'.$path;
+    }
+
+    /**
+     * Has the following method signature:
+     * function (ServerRequestInterface $request, ResponseInterface $response): ResponseInterface {}
+     *
+     * Validation errors are stored in a middleware attribute:
+     * $request->getAttribute(Middleware::KEY, [])[JsonValidator::KEY];
+     *
+     * @param callable $errorHandler
+     * @return void
+     */
+    public function errorHandler(callable $errorHandler)
+    {
+        $this->errorHandler = $errorHandler;
     }
 }

--- a/src/Middleware/JsonValidator.php
+++ b/src/Middleware/JsonValidator.php
@@ -79,6 +79,18 @@ class JsonValidator
     }
 
     /**
+     * Returns the request's JSON validation errors.
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return array|null
+     */
+    public static function getErrors(ServerRequestInterface $request)
+    {
+        return self::getAttribute($request, self::KEY);
+    }
+
+    /**
      * Execute the middleware.
      *
      * @param ServerRequestInterface $request

--- a/src/Middleware/JsonValidator.php
+++ b/src/Middleware/JsonValidator.php
@@ -5,11 +5,22 @@ namespace Psr7Middlewares\Middleware;
 use JsonSchema\Validator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr7Middlewares\Middleware;
+use Psr7Middlewares\Utils\AttributeTrait;
+use Psr7Middlewares\Utils\CallableTrait;
 
 class JsonValidator
 {
+    const KEY = 'JSON_VALIDATION_ERRORS';
+
+    use AttributeTrait;
+    use CallableTrait;
+
     /** @var \stdClass */
     private $schema;
+
+    /** @var callable */
+    private $errorHandler;
 
     /**
      * JsonSchema constructor.
@@ -24,6 +35,7 @@ class JsonValidator
     public function __construct(\stdClass $schema)
     {
         $this->schema = $schema;
+        $this->errorHandler = [$this, 'defaultErrorHandler'];
     }
 
     /**
@@ -82,52 +94,62 @@ class JsonValidator
     {
         $value = $request->getParsedBody();
         if (!is_object($value)) {
-            return $this->invalidateResponse(
-                $response,
-                sprintf('Parsed body must be an object. Type %s is invalid.', gettype($value))
-            );
+            $request = self::setAttribute($request, self::KEY, [
+                sprintf('Parsed body must be an object. Type %s is invalid.', gettype($value)),
+            ]);
+
+            return $this->executeCallable($this->errorHandler, $request, $response);
         }
 
         $validator = new Validator();
         $validator->check($value, $this->schema);
 
         if (!$validator->isValid()) {
-            return $this->invalidateResponse(
-                $response,
-                'Unprocessable Entity',
-                [
-                    'Content-Type' => 'application/json',
-                ],
-                json_encode($validator->getErrors(), JSON_UNESCAPED_SLASHES)
-            );
+            $request = self::setAttribute($request, self::KEY, $validator->getErrors());
+
+            return $this->executeCallable($this->errorHandler, $request, $response);
         }
 
         return $next($request, $response);
     }
 
     /**
+     * @param ServerRequestInterface $request
      * @param ResponseInterface $response
-     * @param string $reason
-     * @param string[] $headers
-     * @param string|null $body
-     *
      * @return ResponseInterface
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */
-    private function invalidateResponse(ResponseInterface $response, $reason, array $headers = [], $body = null)
-    {
-        $response = $response->withStatus(422, $reason);
+    private function defaultErrorHandler(
+        ServerRequestInterface $request,
+        ResponseInterface $response
+    ) {
+        $response = $response->withStatus(422, 'Unprocessable Entity')
+            ->withHeader('Content-Type', 'application/json');
 
-        foreach ($headers as $name => $value) {
-            $response = $response->withHeader($name, $value);
-        }
+        $middlewareAttribute = $request->getAttribute(Middleware::KEY, []);
 
-        if ($body !== null) {
+        if (isset($middlewareAttribute[self::KEY])) {
+            /** @var ResponseInterface $response */
             $stream = $response->getBody();
-            $stream->write($body);
+            $stream->write(json_encode($middlewareAttribute[self::KEY], JSON_UNESCAPED_SLASHES));
         }
 
         return $response;
+    }
+
+    /**
+     * Has the following method signature:
+     * function (ServerRequestInterface $request, ResponseInterface $response): ResponseInterface {}
+     *
+     * Validation errors are stored in a middleware attribute:
+     * $request->getAttribute(Middleware::KEY, [])[JsonValidator::KEY];
+     *
+     * @param callable $errorHandler
+     * @return void
+     */
+    public function errorHandler(callable $errorHandler)
+    {
+        $this->errorHandler = $errorHandler;
     }
 }

--- a/tests/JsonSchemaTest.php
+++ b/tests/JsonSchemaTest.php
@@ -216,8 +216,7 @@ JSON
         $wasCalled = false;
         $this->validator->errorHandler(
             function (ServerRequestInterface $request, ResponseInterface $response) use (&$wasCalled) {
-                self::assertNotCount(0, $middleware = $request->getAttribute(\Psr7Middlewares\Middleware::class));
-                self::assertNotCount(0, $middleware[JsonValidator::KEY]);
+                self::assertNotCount(0, JsonValidator::getErrors($request));
 
                 $wasCalled = true;
             }

--- a/tests/JsonValidatorTest.php
+++ b/tests/JsonValidatorTest.php
@@ -203,8 +203,7 @@ class JsonValidatorTest extends Base
         $wasCalled = false;
         $this->validator->errorHandler(
             function (ServerRequestInterface $request, ResponseInterface $response) use (&$wasCalled) {
-                self::assertNotCount(0, $middleware = $request->getAttribute(\Psr7Middlewares\Middleware::class));
-                self::assertNotCount(0, $middleware[JsonValidator::KEY]);
+                self::assertNotCount(0, JsonValidator::getErrors($request));
 
                 $wasCalled = true;
             }


### PR DESCRIPTION
based on some feedback here:
https://github.com/oscarotero/psr7-middlewares/pull/46

the error handler receives the psr request, response, and an array of validation errors. the default error handler responds with a 422 status code, application/json content-type, and the json-encoded array of errors.

the route-based multi-file wrapper also accepts an error handler override, which is passed through to the underlying validator.

@oscarotero @sbol-coolblue please tell me what you think.