### PR TITLE
add default param to AttributeTrait::getAttribute

### DIFF
--- a/src/Utils/AttributeTrait.php
+++ b/src/Utils/AttributeTrait.php
@@ -32,16 +32,19 @@ trait AttributeTrait
      *
      * @param ServerRequestInterface $request
      * @param string                 $name
+     * @param mixed|null             $default
      *
-     * @return mixed
+     * @return mixed|null
      */
-    private static function getAttribute(ServerRequestInterface $request, $name)
+    private static function getAttribute(ServerRequestInterface $request, $name, $default = null)
     {
-        $attributes = $request->getAttribute(Middleware::KEY);
+        $attributes = $request->getAttribute(Middleware::KEY, []);
 
         if (isset($attributes[$name])) {
             return $attributes[$name];
         }
+
+        return $default;
     }
 
     /**


### PR DESCRIPTION
add default param to \Psr7Middlewares\Utils\AttributeTrait::getAttribute.

the optional default value is null, so the change should be backwards compatible.

this change allows me to specify, for example, that an array should be returned regardless. this saves me from having to do some other type-checking code in all of my consuming methods.

@oscarotero what do you think?