### PR TITLE
Make BasicAuthentication::checkUserPassword() protected.

### DIFF
--- a/src/Middleware/BasicAuthentication.php
+++ b/src/Middleware/BasicAuthentication.php
@@ -61,7 +61,7 @@ class BasicAuthentication
      *
      * @return bool
      */
-    private function checkUserPassword($username, $password)
+    protected function checkUserPassword($username, $password)
     {
         if (!isset($this->users[$username]) || $this->users[$username] !== $password) {
             return false;


### PR DESCRIPTION
Useful to be able to override checkUserPassword(), for example if you
want to add a version which checks a password against a hashed password.