### PR TITLE
Allow same middleware named in different namespaces

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -19,10 +19,15 @@ class Middleware
      * Register a new namespace.
      *
      * @param string $namespace
+     * @param bool   $prepend
      */
-    public static function registerNamespace($namespace)
+    public static function registerNamespace($namespace, $prepend = false)
     {
-        self::$namespaces[] = $namespace;
+        if (false === $prepend) {
+            self::$namespaces[] = $namespace;
+        } else {
+            array_unshift(self::$namespaces, $namespace);
+        }
     }
 
     /**


### PR DESCRIPTION
Hello Oscar,

In past few days, I've created a middleware (with a different implementation code, but with same name) called `AccessLog`.

Actually, when we use 

```
use Psr7Middlewares\Middleware;

Middleware::registerNamespace("My\Namespace");
```
We cannot used or own Middleware.

I suggest this PR to solve the conflict, and allow to choose what middleware must prioritary called.

What do you think about this idea ?

Laurent 

PS: Idea come from Respect/Validation package ( see https://github.com/Respect/Validation/blob/master/docs/README.md#custom-rules )