### PR TITLE
Filter list of acceptable headers; use default if the client accepts everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,13 +714,11 @@ $middlewares = [
 You can optionally specify the formats which your server supports. In the following example, the FormatNegotiator will only negotiate html, pdf and xml.
 
 ```php
-Middleware::FormatNegotiator(
-    [
-        'html' => [['html', 'htm', 'php'], ['text/html', 'application/xhtml+xml']],
-        'pdf' => [['pdf'], ['application/pdf', 'application/x-download']],
-        'xml' => [['xml'], ['text/xml', 'application/xml', 'application/x-xml']]
-    ]
-)
+Middleware::FormatNegotiator([
+    'html' => [['html', 'htm', 'php'], ['text/html', 'application/xhtml+xml']],
+    'pdf' => [['pdf'], ['application/pdf', 'application/x-download']],
+    'xml' => [['xml'], ['text/xml', 'application/xml', 'application/x-xml']]
+])
 ```
 
 ### FormTimestamp

--- a/README.md
+++ b/README.md
@@ -711,14 +711,25 @@ $middlewares = [
 ];
 ```
 
-You can optionally specify the formats which your server supports. In the following example, the FormatNegotiator will only negotiate html, pdf and xml.
+You can optionally specify the formats which your server supports, in priority order, with the first element being the default.
 
 ```php
+//This will only negotiate html, pdf and xml. html is the default.
 Middleware::FormatNegotiator([
     'html' => [['html', 'htm', 'php'], ['text/html', 'application/xhtml+xml']],
     'pdf' => [['pdf'], ['application/pdf', 'application/x-download']],
     'xml' => [['xml'], ['text/xml', 'application/xml', 'application/x-xml']]
 ])
+```
+
+If the client requests a format which is not supported by the server, then the default format will be used. If you wish to generate a 406 Not Acceptable response instead, set the default format to null.
+
+```php
+//This will generate a 406 Not Acceptable response if the client requests anything other than html.
+Middleware::FormatNegotiator([
+        'html' => [['html', 'htm', 'php'], ['text/html', 'application/xhtml+xml']]
+    ])
+    ->defaultFormat(null)
 ```
 
 ### FormTimestamp

--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ use Psr7Middlewares\Middleware\FormatNegotiator;
 
 $middlewares = [
 
-    Middleware::FormatNegotiator(['html', 'pdf', 'xml']) //(optional param) specify formats which your server accepts, in priority order. (by default is everything)
+    Middleware::FormatNegotiator()
         ->defaultFormat('html') //(optional) default format if it's unable to detect. (by default is "html")
         ->addFormat('tiff', ['image/tiff', 'image/x-tiff']), //(optional) add a new format associated with mimetypes
 
@@ -709,6 +709,18 @@ $middlewares = [
         return $next($request, $response);
     }
 ];
+```
+
+You can optionally specify the formats which your server supports. In the following example, the FormatNegotiator will only negotiate html, pdf and xml.
+
+```php
+Middleware::FormatNegotiator(
+    [
+        'html' => [['html', 'htm', 'php'], ['text/html', 'application/xhtml+xml']],
+        'pdf' => [['pdf'], ['application/pdf', 'application/x-download']],
+        'xml' => [['xml'], ['text/xml', 'application/xml', 'application/x-xml']]
+    ]
+)
 ```
 
 ### FormTimestamp

--- a/README.md
+++ b/README.md
@@ -698,8 +698,7 @@ use Psr7Middlewares\Middleware\FormatNegotiator;
 
 $middlewares = [
 
-    Middleware::FormatNegotiator()
-        ->setPriorities(['html', 'pdf', 'xml']) //(optional) specify formats which your server accepts. (by default is everything)
+    Middleware::FormatNegotiator(['html', 'pdf', 'xml']) //(optional param) specify formats which your server accepts, in priority order. (by default is everything)
         ->defaultFormat('html') //(optional) default format if it's unable to detect. (by default is "html")
         ->addFormat('tiff', ['image/tiff', 'image/x-tiff']), //(optional) add a new format associated with mimetypes
 

--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ use Psr7Middlewares\Middleware\FormatNegotiator;
 $middlewares = [
 
     Middleware::FormatNegotiator()
+        ->setPriorities(['html', 'pdf', 'xml']) //(optional) specify formats which your server accepts. (by default is everything)
         ->defaultFormat('html') //(optional) default format if it's unable to detect. (by default is "html")
         ->addFormat('tiff', ['image/tiff', 'image/x-tiff']), //(optional) add a new format associated with mimetypes
 

--- a/src/Middleware/FormatNegotiator.php
+++ b/src/Middleware/FormatNegotiator.php
@@ -129,17 +129,11 @@ class FormatNegotiator
     }
 
     /**
-     * Sets the formats which the server supports.
-     *
-     * @param string[] $priorities
-     *
-     * @return self
+     * @param string[]|null $priorities Formats which the server supports, in priority order.
      */
-    public function setPriorities($priorities)
+    public function __construct($priorities = null)
     {
         $this->priorities = $priorities;
-
-        return $this;
     }
 
     /**

--- a/src/Middleware/FormatNegotiator.php
+++ b/src/Middleware/FormatNegotiator.php
@@ -23,11 +23,6 @@ class FormatNegotiator
     private $default = 'html';
 
     /**
-     * @var string[] Formats which the server supports
-     */
-    private $priorities = array();
-
-    /**
      * @var array Available formats with the mime types
      */
     private $formats = [
@@ -129,11 +124,13 @@ class FormatNegotiator
     }
 
     /**
-     * @param string[]|null $priorities Formats which the server supports, in priority order.
+     * @param array|null $formats Formats which the server supports, in priority order.
      */
-    public function __construct($priorities = null)
+    public function __construct($formats = null)
     {
-        $this->priorities = $priorities;
+        if (!empty($formats)) {
+            $this->formats = $formats;
+        }
     }
 
     /**
@@ -196,18 +193,7 @@ class FormatNegotiator
             return null;
         }
 
-        if (empty($this->priorities)) {
-            $formats = $this->formats;
-        } else {
-            //Filter the list of formats.
-            $formats = [];
-            foreach ($this->priorities as $priority) {
-                if (isset($this->formats[$priority])) {
-                    $formats[$priority] = $this->formats[$priority];
-                }
-            }
-        }
-        $headers = call_user_func_array('array_merge', array_column($formats, 1));
+        $headers = call_user_func_array('array_merge', array_column($this->formats, 1));
         $mime = $this->negotiateHeader($accept, new Negotiator(), $headers);
 
         if ($mime !== null) {


### PR DESCRIPTION
Added a priorities member variable, which allows the dev to filter the list of acceptable headers.

Usage:

```
//Code
Middleware::FormatNegotiator()
    ->setPriorities(['json', 'zip'])
    ->defaultFormat('json')

//Request header
Accept: application/pdf, application/zip

//Result: 
FormatNegotiator::getFormat($request) === "zip"
```

getFromHeader will return null if the accept header is either missing, or set to accept everything. This will allow the default to be used instead.

Usage:

```
//Code
Middleware::FormatNegotiator()
    ->defaultFormat('json')

//Request header
Accept: */*

//Result: 
FormatNegotiator::getFormat($request) === "json"
```