### PR TITLE
Migrate to PHPUnit6

### DIFF
--- a/tests/Base.php
+++ b/tests/Base.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Response;
@@ -7,7 +8,7 @@ use Zend\Diactoros\Stream;
 use Zend\Diactoros\Uri;
 use Relay\RelayBuilder;
 
-abstract class Base extends PHPUnit_Framework_TestCase
+abstract class Base extends TestCase
 {
     /**
      * @param string $uri

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,4 +5,8 @@ error_reporting(E_ALL);
 include_once dirname(__DIR__).'/vendor/autoload.php';
 include_once __DIR__.'/Base.php';
 
-PHPUnit_Framework_Error_Notice::$enabled = true;
+if (class_exists('PHPUnit\Framework\Error\Notice')) {
+    PHPUnit\Framework\Error\Notice::$enabled = true;
+} else {
+    PHPUnit_Framework_Error_Notice::$enabled = true;
+}


### PR DESCRIPTION
Fixing tests failing due to not found PHPUnit_Framework_TestCase. There is still a test failing, but it does due to Geolocation issue.